### PR TITLE
Bugfix 1

### DIFF
--- a/names.js
+++ b/names.js
@@ -33,8 +33,8 @@ $(document).ready(function(){
   $('#submitB').click(function(){
     var boxInput = $("textarea[name=words]").val();
     //console.log(boxInput);
-    var re = /\s*[,\n\t\r;]\s*/
-    var wordList = boxInput.trim().split(re); //trim() is equivalent to Python's strip()
+    var re = /\s*[,\n\t\r;]+\s*/ //captures multiple newlines, multiple commas, etc.
+    var wordList = boxInput.trim().split(re); //trim() is like Python's strip()
     //console.log(wordList); //debugging
 
     if (wordList.length > 1) {

--- a/names.js
+++ b/names.js
@@ -34,7 +34,7 @@ $(document).ready(function(){
     var boxInput = $("textarea[name=words]").val();
     //console.log(boxInput);
     var re = /\s*[,\n\t\r;]\s*/
-    var wordList = boxInput.split(re);
+    var wordList = boxInput.trim().split(re); //trim() is equivalent to Python's strip()
     //console.log(wordList); //debugging
 
     if (wordList.length > 1) {


### PR DESCRIPTION
Fixed bug where a newline before or after the words was counted as a separate word; now also allows for multiple newlines, commas, tabs, etc. between words (in case of double-spaced text or typos).
